### PR TITLE
fix: .html suffix missing in url.

### DIFF
--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -40,7 +40,7 @@
       {{end}}
       {{if .NextExample}}
       <p class="next">
-        下一个例子: <a href="{{.NextExample.ID}}">{{.NextExample.Name}}</a>
+        下一个例子: <a href="{{.NextExample.ID}}.html">{{.NextExample.Name}}</a>
       </p>
       {{end}}
 {{ template "footer" }}

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -13,12 +13,12 @@
       </p>
 
       <p>
-        <em>Go by Example</em> 是对 Go 基于实践的介绍，包含一系列带有注释说明的示例程序。查看<a href="hello-world">第一个例子</a>或者浏览下面的完整列表吧。
+        <em>Go by Example</em> 是对 Go 基于实践的介绍，包含一系列带有注释说明的示例程序。查看<a href="hello-world.html">第一个例子</a>或者浏览下面的完整列表吧。
       </p>
 
       <ul>
       {{range .}}
-        <li><a href="{{.ID}}">{{.Name}}</a></li>
+        <li><a href="{{.ID}}.html">{{.Name}}</a></li>
       {{end}}
       </ul>
 {{ template "footer" }}

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -334,7 +334,7 @@ func renderExamples(examples []*Example) {
 	_, err = exampleTmpl.Parse(mustReadFile("templates/example.tmpl"))
 	check(err)
 	for _, example := range examples {
-		exampleF, err := os.Create(siteDir + "/" + example.ID+".html")
+		exampleF, err := os.Create(siteDir + "/" + example.ID + ".html")
 		check(err)
 		exampleTmpl.Execute(exampleF, example)
 	}


### PR DESCRIPTION
fix 404 introduced in [this commit](https://github.com/gobyexample-cn/gobyexample/commit/04274384ba8fd13d530036f572544814d97554e4).